### PR TITLE
Makefile: fix verbose objcopy

### DIFF
--- a/Makefile.miniboot
+++ b/Makefile.miniboot
@@ -135,7 +135,7 @@ all: $(BIN)
 
 $(BIN): $(ELF)
 	@echo "  BIN     $@"
-	$(V)$(OBJCOPY) -O binary $(ELF) $(BIN)
+	$(_V)$(OBJCOPY) -O binary $(ELF) $(BIN)
 
 $(ELF): $(OBJS)
 	@echo "  LINK    $@"


### PR DESCRIPTION
It was using $(V) instead of $(_V) which caused objcopy path to be prepended to 1, breaking build